### PR TITLE
Add framework-specific install examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ MIT — see [LICENSE](LICENSE) for details.
 
 
 
-## Framework - Specific Install Examples
+## Framework-Specific Install Examples
 
 
 ### LangChain
 ```bash
-pip install langchain agent-governance
+pip install langchain ai-agent-governance
 ```
 
 --- 
@@ -181,7 +181,7 @@ pip install langchain agent-governance
 
 ### CrewAI
 ```bash
-pip install crewai agent-governance
+pip install crewai ai-agent-governance
 ```
 
 
@@ -190,5 +190,5 @@ pip install crewai agent-governance
 
 ### AutoGen
 ```bash
-pip install pyautogen agent-governance
+pip install pyautogen ai-agent-governance
 ```

--- a/README.md
+++ b/README.md
@@ -165,3 +165,30 @@ MIT — see [LICENSE](LICENSE) for details.
 *Building the governance layer for the agentic era*
 
 </div>
+
+
+
+## Framework - Specific Install Examples
+
+
+### LangChain
+```bash
+pip install langchain agent-governance
+```
+
+--- 
+
+
+### CrewAI
+```bash
+pip install crewai agent-governance
+```
+
+
+---
+
+
+### AutoGen
+```bash
+pip install pyautogen agent-governance
+```


### PR DESCRIPTION
Added framework-specific install examples for LangChain, CrewAI, and AutoGen as requested in issue #4.